### PR TITLE
Feature: Run DB Migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM tiangolo/uwsgi-nginx-flask:python3.6
 
-COPY . /www/app
+COPY . /app
 
-WORKDIR /www/app
+WORKDIR /app
 
-ENV UWSGI_INI /www/app/uwsgi.ini
+ENV UWSGI_INI /app/uwsgi.ini
 
 # Install dependencies
 RUN pip install -r requirements.lock

--- a/prestart.sh
+++ b/prestart.sh
@@ -1,0 +1,6 @@
+run_migrations() {
+    echo 'Running migrations'
+    flask db upgrade
+}
+
+run_migrations()


### PR DESCRIPTION
## What?
Add support to run migrations via `prestart.sh` script.

## Why?
Any migration should automatically run.